### PR TITLE
wordcounter component responsive down to 600px

### DIFF
--- a/style.css
+++ b/style.css
@@ -178,9 +178,27 @@ input:focus, textarea:focus {
     padding: 10px;
     padding-left: 16px;
     border-radius: 10px;
-    width: 1000px;
+    width: 70%;
     color: #ddd
 }
+
+@media only screen and (max-width: 1250px) {
+    .word-counter textarea, .word-counter-header, .word-counter-footer {
+        width: 60%;
+    }
+}
+
+@media only screen and (max-width: 975px) {
+    .word-counter-sidebar {
+        max-width: 200px;
+    }
+    .index-main {
+        padding: 10px;
+        padding-top: 55px;
+    }
+  }
+
+
 .word-counter textarea {
     border: 1px solid #333;
     background-color: #111;


### PR DESCRIPTION
Word counter is responsive down to 600px now. 
Positioning of the counter will have to change when you get to mobile. You'll probably have to move the counter to the bottom of the screen and make the text area height much smaller.